### PR TITLE
fix: remove recompose transform-imports from babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -53,10 +53,6 @@
               "transform": "redux-form/es/${member}",
               "preventFullImport": true
             },
-            "recompose": {
-              "transform": "recompose/${member}",
-              "preventFullImport": true
-            },
             "react-virtualized": {
               "transform": "react-virtualized/dist/es/${member}",
               "preventFullImport": true


### PR DESCRIPTION
```Module not found: Error: Can't resolve recompose/HOC```

client側のproduction build時に上記エラーが出ます
transform-importsがflowtype用の```type HOC```を誤認識している？