### PR TITLE
Add snapshot test example for counter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "browser": true,
     "node": true,
     "mocha": true,
+    "jest": true,
     "es6": true
   },
 

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "postcss-selector-not": "^3.0.1",
     "power-assert": "^1.5.0",
     "prettier": "^1.12.1",
+    "react-test-renderer": "^16.3.2",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.5.0",

--- a/src/shared/components/organisms/Counter/__tests__/Counter.test.js
+++ b/src/shared/components/organisms/Counter/__tests__/Counter.test.js
@@ -1,0 +1,9 @@
+/* @flow */
+import React from "react";
+import renderer from "react-test-renderer";
+import Counter from "../Counter";
+
+test("Counter: render correctly", () => {
+  const tree = renderer.create(<Counter counterValue={1} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/shared/components/organisms/Counter/__tests__/__snapshots__/Counter.test.js.snap
+++ b/src/shared/components/organisms/Counter/__tests__/__snapshots__/Counter.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Counter: render correctly 1`] = `
+<div
+  className="sc-bdVaJa khUSez"
+>
+  access counter: 
+  1
+</div>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6781,7 +6781,7 @@ react-hot-loader@^4.0.1:
     prop-types "^15.6.1"
     shallowequal "^1.0.2"
 
-react-is@^16.3.1:
+react-is@^16.3.1, react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
@@ -6856,6 +6856,15 @@ react-router@v3.2.0:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-test-renderer@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react-transform-catch-errors@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Counter に Snapshot test を追加

小さなコンポーネントに追加してもあまり意味が無いので、大きな component から見た時の整合性を取るようにする。リファクタ時に最終的に辻褄を合わせるのに使う。

とはいえ Counter は外部依存がなくてそんなに面白くはなかった。とりあえずサンプルってことで。