### PR TITLE
Remove modules from greenkeeper's ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,11 +162,6 @@
   "greenkeeper": {
     "ignore": [
       "react-router",
-      "webpack",
-      "webpack-flush-chunks",
-      "webpack-dev-middleware",
-      "webpack-hot-middleware",
-      "webpack-hot-server-middleware",
       "eslint-config-airbnb",
       "flow-bin"
     ]


### PR DESCRIPTION
webpack 系のモジュールはすでに最新になっているようなので、greenkeeper の ignore から外すという変更です。

eslint-config-airbnb と flow-bin は上げると lint error / type error が出るようだったのでそのままにしています。