### PR TITLE
fix: render SSR when prefetch response code is 400

### DIFF
--- a/spec/agreed/agreed.js
+++ b/spec/agreed/agreed.js
@@ -1,4 +1,7 @@
 module.exports = [
+  "./agreedsample/500_get.json5",
+  "./agreedsample/400_get.json5",
+  "./agreedsample/404_get.json5",
   "./agreedsample/get.json5",
   "./uploadsample/post.json5",
   "./search/getSearchById.json5",

--- a/spec/agreed/agreedsample/400_get.json5
+++ b/spec/agreed/agreedsample/400_get.json5
@@ -2,8 +2,12 @@
   request: {
     path: '/agreedsample',
     method: 'GET',
+    query: {
+      status: '400',
+    },
   },
   response: {
+    status: 400,
     body: {
       results: {
         text: '{:text}',
@@ -14,3 +18,4 @@
     },
   },
 }
+

--- a/spec/agreed/agreedsample/404_get.json5
+++ b/spec/agreed/agreedsample/404_get.json5
@@ -2,8 +2,12 @@
   request: {
     path: '/agreedsample',
     method: 'GET',
+    query: {
+      status: '404',
+    },
   },
   response: {
+    status: 404,
     body: {
       results: {
         text: '{:text}',
@@ -14,3 +18,5 @@
     },
   },
 }
+
+

--- a/spec/agreed/agreedsample/500_get.json5
+++ b/spec/agreed/agreedsample/500_get.json5
@@ -2,8 +2,12 @@
   request: {
     path: '/agreedsample',
     method: 'GET',
+    query: {
+      status: '500',
+    },
   },
   response: {
+    status: 500,
     body: {
       results: {
         text: '{:text}',
@@ -14,3 +18,5 @@
     },
   },
 }
+
+

--- a/src/server/middlewares/reduxApp.js
+++ b/src/server/middlewares/reduxApp.js
@@ -140,6 +140,7 @@ export default function createReduxApp(config) {
             }
             // TODO(yosuke): 401系だったらリダイレクトが良いかも。
             // その他の400系の場合は render させる
+            res.statusCode = err.statusCode;
             return renderSSR({
               res,
               store,

--- a/src/server/services/AgreedSample.js
+++ b/src/server/services/AgreedSample.js
@@ -15,7 +15,7 @@ export default class AgreedSample {
     this.pathname = "agreedsample";
   }
 
-  read(req: any, _resource: any, _params: any, _config: any) {
-    return read(this.axios, this.name, this.pathname, {});
+  read(req: any, _resource: any, params: any, _config: any) {
+    return read(this.axios, this.name, this.pathname, params);
   }
 }

--- a/src/server/services/utils.js
+++ b/src/server/services/utils.js
@@ -28,12 +28,20 @@ export function read(axios: any, name: string, pathname: string, query: any) {
 
       return results;
     },
-    error =>
-      rejectWith(fumble.create(), {
+    error => {
+      if (error.response) {
+        return rejectWith(fumble.http.create(error.response.status), {
+          name,
+          formattedUrl,
+          reason: error.response.data,
+        });
+      }
+      return rejectWith(fumble.create(500), {
         name,
         formattedUrl,
         reason: error.message,
-      }),
+      });
+    },
   );
 }
 

--- a/src/shared/components/organisms/AgreedSample/index.js
+++ b/src/shared/components/organisms/AgreedSample/index.js
@@ -11,7 +11,14 @@ import {
 import AgreedSample from "./AgreedSample";
 
 const enhancer = compose(
-  asyncLoader((_, { dispatch }) => dispatch(getText())),
+  asyncLoader(({ location }, { dispatch }) => {
+    const { query: locationQuery } = location;
+    if (!locationQuery) {
+      return dispatch(getText());
+    }
+    const { status } = locationQuery;
+    return dispatch(getText(status));
+  }),
   connect(state => ({
     text: state.page.agreedSample.text,
   })),

--- a/src/shared/redux/middleware/apiErrorMiddleware.js
+++ b/src/shared/redux/middleware/apiErrorMiddleware.js
@@ -24,11 +24,15 @@ export default function apiErrorMiddleware() {
         const { statusCode } = error;
         if (!statusCode || statusCode >= 500) {
           dispatch(showAlert("サービスに接続できませんでした。"));
+        } else if (statusCode === 400) {
+          dispatch(showAlert("不正なリクエストが発生しました。"));
         } else if (statusCode === 401) {
           const { routing } = getState();
           const { locationBeforeTransitions } = routing;
           const { pathname } = locationBeforeTransitions;
           dispatch(replace(`/login?location=${pathname}`));
+        } else if (statusCode === 404) {
+          dispatch(showAlert("何も見つかりませんでした。"));
         }
 
         return Promise.reject(error);

--- a/src/shared/redux/modules/agreedSample.js
+++ b/src/shared/redux/modules/agreedSample.js
@@ -22,10 +22,10 @@ export const getTextRequest = createAction(AGREED_SAMPLE_GET_TEXT_REQUEST);
 export const getTextSuccess = createAction(AGREED_SAMPLE_GET_TEXT_SUCCESS);
 export const getTextFail = createAction(AGREED_SAMPLE_GET_TEXT_FAIL);
 
-export function getText(): Promise<{ text: string }> {
+export function getText(status: ?string): Promise<{ text: string }> {
   return steps(
-    getTextRequest({ resource: "agreedSample" }),
-    ({ payload }) => fetchrRead(payload),
+    getTextRequest(),
+    fetchrRead({ resource: "agreedSample", params: { status } }),
     [getTextSuccess, getTextFail],
   );
 }


### PR DESCRIPTION
kani さんからの指摘で SSR 実行中のprefetch時にエラーが走るとすべて500のエラーとなる現象を解消した。

実際には 400系は apiErrorMiddleware でエラー発生時にmodalを出し、その上でrenderさせている。 500系の時は落ちたのと同等扱い。

see:
localhost:3000/agreedsample?status=400