### PR TITLE
fix(test): change to strict mode

### DIFF
--- a/src/server/services/__tests__/AccessToken.create.test.js
+++ b/src/server/services/__tests__/AccessToken.create.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import assert from "power-assert";
+import assert from "assert";
 import cookie from "cookie";
 import configs from "server/configs";
 import AccessToken, { verify, ACCESS_TOKEN_COOKIE_NAME } from "../AccessToken";
@@ -26,7 +26,7 @@ test("AccessToken: create success", async () => {
       },
       configs.auth.secret,
     ).then(token => {
-      assert(token.sub === "scott");
+      assert.strictEqual(token.sub, "scott");
     });
   });
 });
@@ -44,8 +44,8 @@ test("AccessToken: create failure", async done => {
   };
 
   return (accessToken: any).create(req, void 0, params).then(done.fail, e => {
-    assert(e.statusCode === 400);
-    assert(e.message === "Bad Request");
+    assert.strictEqual(e.statusCode, 400);
+    assert.strictEqual(e.message, "Bad Request");
     done();
   });
 });

--- a/src/server/services/__tests__/AccessToken.delete.test.js
+++ b/src/server/services/__tests__/AccessToken.delete.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import assert from "power-assert";
+import assert from "assert";
 import cookie from "cookie";
 import configs from "server/configs";
 import AccessToken from "../AccessToken";
@@ -10,6 +10,6 @@ test("AccessToken: delete success", async () => {
   const response = await accessToken.delete();
   const cookies = response.meta.headers["set-cookie"];
   const parsedCookie = cookie.parse(cookies);
-  assert(parsedCookie["access-token"] === "null");
-  assert(parsedCookie.Expires === "Thu, 01 Jan 1970 00:00:00 GMT");
+  assert.strictEqual(parsedCookie["access-token"], "null");
+  assert.strictEqual(parsedCookie.Expires, "Thu, 01 Jan 1970 00:00:00 GMT");
 });

--- a/src/server/services/__tests__/AgreedSample.read.test.js
+++ b/src/server/services/__tests__/AgreedSample.read.test.js
@@ -1,6 +1,6 @@
 /* @flow */
 /* eslint-disable global-require */
-import assert from "power-assert";
+import assert from "assert";
 import configs from "server/configs";
 import AgreedSample from "../AgreedSample";
 
@@ -8,5 +8,5 @@ test("AgreedSample: read success", async () => {
   const getText = require("../../../../spec/agreed/agreedsample/get.json5");
   const agreedSample = new AgreedSample(configs);
   const result = await agreedSample.read();
-  assert.deepEqual(result, getText.response.values);
+  assert.deepStrictEqual(result, getText.response.values);
 });

--- a/src/server/uploaders/__tests__/UploadSample.test.js
+++ b/src/server/uploaders/__tests__/UploadSample.test.js
@@ -1,7 +1,6 @@
 /* @flow */
 import fs from "fs";
 import path from "path";
-import assert from "assert";
 import multer from "multer";
 import express from "express";
 import FormData from "form-data";
@@ -29,7 +28,8 @@ test.skip("UploadSample: upload file", done => {
 
     form.submit(`http://localhost:${port}${apiPath}`, (err, res) => {
       if (err) {
-        assert.fail(err);
+        done.fail(err);
+        return;
       }
 
       assertStream.expect({

--- a/src/server/uploaders/__tests__/UploadSample.test.js
+++ b/src/server/uploaders/__tests__/UploadSample.test.js
@@ -1,10 +1,10 @@
 /* @flow */
 import fs from "fs";
 import path from "path";
+import assert from "assert";
 import multer from "multer";
 import express from "express";
 import FormData from "form-data";
-import assert from "power-assert";
 import AssertStream from "assert-stream";
 import UploadSample from "../UploadSample";
 import configs from "../../configs";

--- a/src/shared/components/atoms/__tests__/Indicator.test.js
+++ b/src/shared/components/atoms/__tests__/Indicator.test.js
@@ -1,16 +1,16 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import Indicator, { Loader } from "../Indicator";
 
 test("Indicator: loading", () => {
   const props = { loading: true };
   const wrapper = mount(<Indicator {...props} />);
-  assert.equal(wrapper.find(Loader).length, 1);
+  assert.strictEqual(wrapper.find(Loader).length, 1);
 });
 
 test("Indicator: not loading", () => {
   const props = { loading: false };
   const wrapper = mount(<Indicator {...props} />);
-  assert.equal(wrapper.find(Loader).length, 0);
+  assert.strictEqual(wrapper.find(Loader).length, 0);
 });

--- a/src/shared/components/atoms/__tests__/Menu.test.js
+++ b/src/shared/components/atoms/__tests__/Menu.test.js
@@ -1,6 +1,6 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import Menu from "../Menu";
 
 const MenuItem = () => <div>MenuItem</div>;
@@ -12,5 +12,5 @@ test("Menu: has children", () => {
       <MenuItem />
     </Menu>,
   );
-  assert.equal(wrapper.find(MenuItem).length, 2);
+  assert.strictEqual(wrapper.find(MenuItem).length, 2);
 });

--- a/src/shared/components/atoms/__tests__/MenuItem.test.js
+++ b/src/shared/components/atoms/__tests__/MenuItem.test.js
@@ -1,6 +1,6 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import MenuItem from "../MenuItem";
 
 const LinkText = () => <div>LinkText</div>;
@@ -15,7 +15,7 @@ test("MenuItem: checked", () => {
       <LinkText />
     </MenuItem>,
   );
-  assert.equal(wrapper.getDOMNode().getAttribute("aria-checked"), "true");
+  assert.strictEqual(wrapper.getDOMNode().getAttribute("aria-checked"), "true");
 });
 
 test("MenuItem: has children", () => {
@@ -28,5 +28,5 @@ test("MenuItem: has children", () => {
       <LinkText />
     </MenuItem>,
   );
-  assert.equal(wrapper.find(LinkText).length, 1);
+  assert.strictEqual(wrapper.find(LinkText).length, 1);
 });

--- a/src/shared/components/atoms/__tests__/Overlay.test.js
+++ b/src/shared/components/atoms/__tests__/Overlay.test.js
@@ -1,6 +1,6 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import Overlay from "../Overlay";
 
 const Text = () => <div>Text</div>;
@@ -13,7 +13,7 @@ test("Overlay: onClick", () => {
     </Overlay>,
   );
   wrapper.simulate("click");
-  assert.equal(onClick.mock.calls.length, 1);
+  assert.strictEqual(onClick.mock.calls.length, 1);
 });
 
 test("Overlay: has children", () => {
@@ -23,5 +23,5 @@ test("Overlay: has children", () => {
       <Text />
     </Overlay>,
   );
-  assert.equal(wrapper.find(Text).length, 1);
+  assert.strictEqual(wrapper.find(Text).length, 1);
 });

--- a/src/shared/components/atoms/__tests__/SearchListItem.test.js
+++ b/src/shared/components/atoms/__tests__/SearchListItem.test.js
@@ -1,6 +1,6 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import { Link } from "react-router";
 import SearchListItem, { Description } from "../SearchListItem";
 
@@ -15,12 +15,15 @@ test("SearchListItem: rendered correctly", () => {
     linkURL: "link",
   };
   const wrapper = mount(<SearchListItem {...props} />);
-  assert.equal(wrapper.find("img").prop("src"), props.item.logo_image_square);
-  assert.equal(wrapper.find("img").prop("alt"), props.item.name);
-  assert.equal(
+  assert.strictEqual(
+    wrapper.find("img").prop("src"),
+    props.item.logo_image_square,
+  );
+  assert.strictEqual(wrapper.find("img").prop("alt"), props.item.name);
+  assert.strictEqual(
     wrapper.find(Link).prop("to"),
     `${props.linkURL}/${props.item.id}`,
   );
-  assert.equal(wrapper.find(Link).text(), props.item.name);
-  assert.equal(wrapper.find(Description).text(), props.item.description);
+  assert.strictEqual(wrapper.find(Link).text(), props.item.name);
+  assert.strictEqual(wrapper.find(Description).text(), props.item.description);
 });

--- a/src/shared/components/atoms/__tests__/SearchMore.test.js
+++ b/src/shared/components/atoms/__tests__/SearchMore.test.js
@@ -1,6 +1,6 @@
+import assert from "assert";
 import React from "react";
 import { mount } from "enzyme";
-import assert from "power-assert";
 import SearchMore from "../SearchMore";
 
 const Item = () => <div>Item</div>;
@@ -14,7 +14,7 @@ test("SearchMore: onShow", () => {
   );
   wrapper.simulate("click");
   wrapper.simulate("keydown");
-  assert.equal(onShow.mock.calls.length, 2);
+  assert.strictEqual(onShow.mock.calls.length, 2);
 });
 
 test("SearchMore: has children", () => {
@@ -25,5 +25,5 @@ test("SearchMore: has children", () => {
     </SearchMore>,
   );
   wrapper.simulate("click");
-  assert.equal(wrapper.find(Item).length, 1);
+  assert.strictEqual(wrapper.find(Item).length, 1);
 });

--- a/src/shared/redux/__tests__/agreedSample.test.js
+++ b/src/shared/redux/__tests__/agreedSample.test.js
@@ -1,5 +1,5 @@
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { getText } from "../modules/agreedSample";
 import { createStore } from "./lib/storeUtils";
 
@@ -16,7 +16,7 @@ Fetchr.registerService({
 test("agreedSample: getText success", async () => {
   const store = createStore({ cookie: {} });
   await store.dispatch(getText());
-  assert.deepEqual(store.getState().page.agreedSample, {
+  assert.deepStrictEqual(store.getState().page.agreedSample, {
     text: "Hello world",
     loading: false,
     loaded: true,
@@ -30,7 +30,7 @@ test("agreedSample: getText failure", async done => {
     await store.dispatch(getText());
     done.fail();
   } catch (_e) {
-    assert.deepEqual(store.getState().page.agreedSample, {
+    assert.deepStrictEqual(store.getState().page.agreedSample, {
       text: "",
       error: true,
       loading: false,

--- a/src/shared/redux/__tests__/auth.checkLogin.test.js
+++ b/src/shared/redux/__tests__/auth.checkLogin.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undefined */
-import assert from "power-assert";
+import assert from "assert";
 import Fetchr from "fetchr";
 import { ACCESS_TOKEN_AUDIENCE_NAME } from "server/services/AccessToken";
 import { checkLogin } from "shared/redux/modules/auth";
@@ -23,7 +23,7 @@ test("auth: checkLogin success", () => {
   const checkLoginAction = checkLogin();
   createWithSignedStore("scott", ACCESS_TOKEN_AUDIENCE_NAME, {}).then(store => {
     store.dispatch(checkLoginAction).then(() => {
-      assert.deepEqual(store.getState().app.auth, {
+      assert.deepStrictEqual(store.getState().app.auth, {
         login: true,
         username: "scott",
       });
@@ -39,11 +39,11 @@ test("auth: checkLogin failure", done => {
   });
 
   store.dispatch(checkLoginAction).then(done.fail, e => {
-    assert.deepEqual(store.getState().app.auth, {
+    assert.deepStrictEqual(store.getState().app.auth, {
       login: false,
-      username: undefined,
+      username: null,
     });
-    assert(e.message === "no token");
+    assert.strictEqual(e.message, "no token");
     return done();
   });
 });

--- a/src/shared/redux/__tests__/auth.login.test.js
+++ b/src/shared/redux/__tests__/auth.login.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-disable no-undefined */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { ACCESS_TOKEN_AUDIENCE_NAME } from "server/services/AccessToken";
 import { login } from "shared/redux/modules/auth";
 import { createStore, createWithSignedStore } from "./lib/storeUtils";
@@ -24,7 +24,7 @@ test("auth: login success username scott", () => {
   const loginAction = login("scott", "tiger");
   createWithSignedStore("scott", ACCESS_TOKEN_AUDIENCE_NAME, {}).then(store => {
     store.dispatch(loginAction).then(() => {
-      assert.deepEqual(store.getState().app.auth, {
+      assert.deepStrictEqual(store.getState().app.auth, {
         login: true,
         username: "scott",
       });
@@ -37,7 +37,7 @@ test("auth: login success username foobar", () => {
   createWithSignedStore("foobar", ACCESS_TOKEN_AUDIENCE_NAME, {}).then(
     store => {
       store.dispatch(loginAction).then(() => {
-        assert.deepEqual(store.getState().app.auth, {
+        assert.deepStrictEqual(store.getState().app.auth, {
           login: true,
           username: "foobar",
         });
@@ -53,7 +53,7 @@ test("auth: login failure invalid audience name", async done => {
     await store.dispatch(loginAction);
     done.fail();
   } catch (e) {
-    assert(e.message === "invalid token");
+    assert.strictEqual(e.message, "invalid token");
   }
   done();
 });
@@ -69,7 +69,7 @@ test("auth: login failure username is short", async done => {
     await store.dispatch(loginAction);
     done.fail();
   } catch (e) {
-    assert.deepEqual(store.getState().app.auth, {
+    assert.deepStrictEqual(store.getState().app.auth, {
       login: false,
       username: null,
     });

--- a/src/shared/redux/__tests__/auth.logout.test.js
+++ b/src/shared/redux/__tests__/auth.logout.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-disable no-undefined */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { ACCESS_TOKEN_AUDIENCE_NAME } from "server/services/AccessToken";
 import { login, logout } from "shared/redux/modules/auth";
 import { createWithSignedStore } from "./lib/storeUtils";
@@ -24,9 +24,9 @@ test("auth: logout success", done => {
   const logoutAction = logout();
   createWithSignedStore("scott", ACCESS_TOKEN_AUDIENCE_NAME, {}).then(store => {
     store.dispatch(logoutAction).then(() => {
-      assert.deepEqual(store.getState().app.auth, {
+      assert.deepStrictEqual(store.getState().app.auth, {
         login: false,
-        username: undefined,
+        username: null,
       });
       done();
     });
@@ -41,16 +41,16 @@ test("auth: logout success when not logged in", done => {
       store
         .dispatch(loginAction)
         .then(() => {
-          assert.deepEqual(store.getState().app.auth, {
+          assert.deepStrictEqual(store.getState().app.auth, {
             login: true,
             username: "foobar",
           });
           return store.dispatch(logoutAction);
         })
         .then(() => {
-          assert.deepEqual(store.getState().app.auth, {
+          assert.deepStrictEqual(store.getState().app.auth, {
             login: false,
-            username: undefined,
+            username: null,
           });
           done();
         });

--- a/src/shared/redux/__tests__/counter.test.js
+++ b/src/shared/redux/__tests__/counter.test.js
@@ -1,5 +1,5 @@
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { times } from "lodash/fp";
 import { increment } from "../modules/counter";
 import { createStore } from "./lib/storeUtils";
@@ -20,7 +20,7 @@ test("counter: increment success", async () => {
 
   await Promise.all(times(() => store.dispatch(incrementAction), 10));
 
-  assert.deepEqual(store.getState().app.counter, {
+  assert.deepStrictEqual(store.getState().app.counter, {
     value: 10,
   });
 });

--- a/src/shared/redux/__tests__/hackerNews.test.js
+++ b/src/shared/redux/__tests__/hackerNews.test.js
@@ -1,5 +1,5 @@
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { fetchItems } from "../modules/hackerNews";
 import { createStore } from "./lib/storeUtils";
 
@@ -20,7 +20,7 @@ test("hackerNews: fetchItems success", async () => {
   await store.dispatch(fetchItemsAction);
   const hackerNewsState = store.getState().page.hackerNews;
 
-  assert.deepEqual(hackerNewsState, {
+  assert.deepStrictEqual(hackerNewsState, {
     loading: false,
     items: searchedItems,
     page: 1,
@@ -36,8 +36,8 @@ test("hackerNews: fetchItems fail", async done => {
     done.fail();
   } catch (e) {
     const hackerNewsState = store.getState().page.hackerNews;
-    assert.equal(hackerNewsState.error, true);
-    assert.equal(e.message, "failure");
+    assert.strictEqual(hackerNewsState.error, true);
+    assert.strictEqual(e.message, "failure");
     done();
   }
 });

--- a/src/shared/redux/__tests__/master.areaMaster.test.js
+++ b/src/shared/redux/__tests__/master.areaMaster.test.js
@@ -1,6 +1,6 @@
 /* @flow */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import {
   INITIAL_STATE,
@@ -66,7 +66,7 @@ test("master: areaMaster success", () => {
     })
     .then(() => {
       const mastersState = store.getState().app.masters;
-      assert.deepEqual(mastersState.areaMaster, {
+      assert.deepStrictEqual(mastersState.areaMaster, {
         loading: false,
         loaded: true,
         items: areaMasters,

--- a/src/shared/redux/__tests__/master.genderMaster.test.js
+++ b/src/shared/redux/__tests__/master.genderMaster.test.js
@@ -1,6 +1,6 @@
 /* @flow */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import {
   INITIAL_STATE,
@@ -66,7 +66,7 @@ test("master: genderMaster success", () => {
     })
     .then(() => {
       const mastersState = store.getState().app.masters;
-      assert.deepEqual(mastersState.genderMaster, {
+      assert.deepStrictEqual(mastersState.genderMaster, {
         loading: false,
         loaded: true,
         items: genderMaster,

--- a/src/shared/redux/__tests__/master.hairColorMaster.js
+++ b/src/shared/redux/__tests__/master.hairColorMaster.js
@@ -1,6 +1,6 @@
 /* @flow */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import {
   INITIAL_STATE,
@@ -66,7 +66,7 @@ test("master: hairColorMaster success", () => {
     })
     .then(() => {
       const mastersState = store.getState().app.masters;
-      assert.deepEqual(mastersState.hairColorMaster, {
+      assert.deepStrictEqual(mastersState.hairColorMaster, {
         loading: false,
         loaded: true,
         items: hairColorMaster,

--- a/src/shared/redux/__tests__/master.hairLengthMaster.test.js
+++ b/src/shared/redux/__tests__/master.hairLengthMaster.test.js
@@ -1,6 +1,6 @@
 /* @flow */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import {
   INITIAL_STATE,
@@ -66,7 +66,7 @@ test("master: hairLengthMaster success", () => {
     })
     .then(() => {
       const mastersState = store.getState().app.masters;
-      assert.deepEqual(mastersState.hairLengthMaster, {
+      assert.deepStrictEqual(mastersState.hairLengthMaster, {
         loading: false,
         loaded: true,
         items: hairLengthMaster,

--- a/src/shared/redux/__tests__/master.loadMaster.test.js
+++ b/src/shared/redux/__tests__/master.loadMaster.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-disable no-undefined */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import * as masters from "../modules/masters";
 import { createStore } from "./lib/storeUtils";
@@ -63,7 +63,7 @@ test("master: loadAll success", done => {
   });
   store.dispatch(loadAllMastersAction).then(() => {
     const state = store.getState().app.masters;
-    assert.deepEqual(state, {
+    assert.deepStrictEqual(state, {
       areaMaster: {
         loading: false,
         loaded: true,
@@ -144,9 +144,13 @@ test("master: load each success", done => {
           const nextState = store.getState().app.masters;
           Object.keys(nextState).forEach(propName => {
             if (propName === actionName) {
-              assert.deepEqual(nextState[propName], expects[propName]);
+              assert.deepStrictEqual(nextState[propName], expects[propName]);
             } else {
-              assert(nextState[propName] === prevState[propName], actionName);
+              assert.strictEqual(
+                nextState[propName],
+                prevState[propName],
+                actionName,
+              );
             }
           });
           prevState = nextState;
@@ -155,7 +159,7 @@ test("master: load each success", done => {
     )
     .then(() => {
       const state = store.getState().app.masters;
-      assert.deepEqual(state, expects);
+      assert.deepStrictEqual(state, expects);
       done();
     });
 });
@@ -169,7 +173,7 @@ test("master: loadAll failure", done => {
   needFailure = "areaMaster";
   store.dispatch(loadAllMastersAction).then(() => {
     const state = store.getState().app.masters;
-    assert.deepEqual(state, {
+    assert.deepStrictEqual(state, {
       areaMaster: {
         loading: false,
         loaded: false,

--- a/src/shared/redux/__tests__/master.menuContentMaster.test.js
+++ b/src/shared/redux/__tests__/master.menuContentMaster.test.js
@@ -1,6 +1,6 @@
 /* @flow */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import {
   INITIAL_STATE,
@@ -66,7 +66,7 @@ test("master: hairLengthMaster success", async () => {
     })
     .then(() => {
       const mastersState = store.getState().app.masters;
-      assert.deepEqual(mastersState.menuContentMaster, {
+      assert.deepStrictEqual(mastersState.menuContentMaster, {
         loading: false,
         loaded: true,
         items: menuContentMaster,

--- a/src/shared/redux/__tests__/search.test.js
+++ b/src/shared/redux/__tests__/search.test.js
@@ -1,5 +1,5 @@
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { findSalonById } from "../modules/search";
 import { createStore } from "./lib/storeUtils";
 
@@ -26,7 +26,7 @@ test("search: findSalonById success", async () => {
   await store.dispatch(findSalonByIdAction);
   const searchState = store.getState().page.search;
 
-  assert.deepEqual(searchState, {
+  assert.deepStrictEqual(searchState, {
     loading: false,
     loaded: true,
     item: searchedItems[0],
@@ -42,8 +42,8 @@ test("search: findSalonById fail", async done => {
     done.fail();
   } catch (e) {
     const searchState = store.getState().page.search;
-    assert.equal(searchState.error, true);
-    assert.equal(e.message, "failure");
+    assert.strictEqual(searchState.error, true);
+    assert.strictEqual(e.message, "failure");
     done();
   }
 });

--- a/src/shared/redux/__tests__/searchList.test.js
+++ b/src/shared/redux/__tests__/searchList.test.js
@@ -1,5 +1,5 @@
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import { range } from "lodash/fp";
 import { searchSearchList, searchMoreSearchList } from "../modules/searchList";
 import { createStore } from "./lib/storeUtils";
@@ -27,7 +27,7 @@ test("searchList: searchSearchList success", async () => {
   await store.dispatch(searchSearchListAction);
   const searchListState = store.getState().page.searchList;
 
-  assert.deepEqual(searchListState, {
+  assert.deepStrictEqual(searchListState, {
     loading: false,
     loaded: true,
     params: {},
@@ -54,8 +54,8 @@ test("searchList: searchSearchList fail", async done => {
     done.fail();
   } catch (e) {
     const searchListState = store.getState().page.searchList;
-    assert.equal(searchListState.error, true);
-    assert.equal(e.message, "failure");
+    assert.strictEqual(searchListState.error, true);
+    assert.strictEqual(e.message, "failure");
     done();
   }
 });
@@ -73,7 +73,7 @@ test("searchList: searchMoreSearchList success", async () => {
   await store.dispatch(searchMoreSearchListAction);
   const searchListState = store.getState().page.searchList;
 
-  assert.deepEqual(searchListState, {
+  assert.deepStrictEqual(searchListState, {
     loading: false,
     loaded: true,
     params: {},
@@ -102,8 +102,8 @@ test("searchList: searchMoreSearchList fail", async done => {
     done.fail();
   } catch (e) {
     const searchListState = store.getState().page.searchList;
-    assert.equal(searchListState.error, true);
-    assert.equal(e.message, "failure");
+    assert.strictEqual(searchListState.error, true);
+    assert.strictEqual(e.message, "failure");
     done();
   }
 });

--- a/src/shared/redux/__tests__/style.searchStyle.test.js
+++ b/src/shared/redux/__tests__/style.searchStyle.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint-disable no-undefined, callback-return */
+import assert from "assert";
 import Fetchr from "fetchr";
-import assert from "power-assert";
 import Immutable from "seamless-immutable";
 import { INITIAL_STATE, searchStyle } from "../modules/style";
 import { createStore } from "./lib/storeUtils";
@@ -24,7 +24,7 @@ test("style: searchStyle success", async () => {
   });
   return store.dispatch(searchStyleAction).then(() => {
     const state = store.getState().page.style;
-    assert.deepEqual(state, {
+    assert.deepStrictEqual(state, {
       loading: false,
       loaded: true,
       params: { query: "foo" },
@@ -43,7 +43,7 @@ test("style: searchStyle failure", done => {
   needFailure = true;
   store.dispatch(searchStyleAction).then(done.fail, () => {
     const state = store.getState().page.style;
-    assert.deepEqual(state, {
+    assert.deepStrictEqual(state, {
       loading: false,
       loaded: false,
       params: { query: "foo" },

--- a/src/shared/redux/__tests__/uploadSample.test.js
+++ b/src/shared/redux/__tests__/uploadSample.test.js
@@ -1,4 +1,4 @@
-import assert from "power-assert";
+import assert from "assert";
 import { uploadFile } from "../modules/uploadSample";
 import { createStore } from "./lib/storeUtils";
 
@@ -7,7 +7,7 @@ test("uploadSample: uploadFile success", async () => {
   const file = "file";
   const uploadFileAction = uploadFile(file);
   await store.dispatch(uploadFileAction);
-  assert.deepEqual(store.getState().page.uploadSample, {
+  assert.deepStrictEqual(store.getState().page.uploadSample, {
     loading: false,
     loaded: true,
     value: "",

--- a/src/shared/redux/modules/__tests__/alert.test.js
+++ b/src/shared/redux/modules/__tests__/alert.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import assert from "power-assert";
+import assert from "assert";
 import Immutable from "seamless-immutable";
 import reducer, { showAlert, clearAlert } from "../alert";
 
@@ -9,7 +9,7 @@ test("State: showAlert", done => {
     message: "",
   });
   const state = reducer(INITIAL_STATE, showAlertAction);
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     message: "test",
   });
   done();
@@ -21,7 +21,7 @@ test("State: clearAlert", done => {
     message: "test",
   });
   const state = reducer(INITIAL_STATE, clearAlertAction);
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     message: "",
   });
   done();

--- a/src/shared/redux/modules/__tests__/auth.test.js
+++ b/src/shared/redux/modules/__tests__/auth.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undefined */
-import assert from "power-assert";
+import assert from "assert";
 import Immutable from "seamless-immutable";
 import reducer, { checkLogin, login, logout } from "../auth";
 
@@ -17,7 +17,7 @@ test("State: checkLoginSuccess", done => {
       sub: "haruka",
     }),
   );
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     login: true,
     username: "haruka",
   });
@@ -33,7 +33,7 @@ test("State: checkLoginFail", done => {
   });
   const checkLoginFail = steps[1];
   const state = reducer(INITIAL_STATE, checkLoginFail());
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     login: false,
     username: null,
   });
@@ -54,7 +54,7 @@ test("State: loginSuccess", done => {
       sub: "haruka",
     }),
   );
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     login: true,
     username: "haruka",
   });
@@ -70,9 +70,9 @@ test("State: loginFail", done => {
   });
   const loginFailAction = steps[1];
   const state = reducer(INITIAL_STATE, loginFailAction());
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     login: false,
-    username: undefined,
+    username: null,
   });
   done();
 });
@@ -86,9 +86,9 @@ test("State: logoutSuccess", done => {
   });
   const logoutSuccessAction = steps[0];
   const state = reducer(INITIAL_STATE, logoutSuccessAction());
-  assert.deepEqual(state, {
+  assert.deepStrictEqual(state, {
     login: false,
-    username: undefined,
+    username: null,
   });
   done();
 });
@@ -102,6 +102,6 @@ test("State: logoutFail", done => {
   });
   const logoutFailAction = steps[1];
   const state = reducer(INITIAL_STATE, logoutFailAction());
-  assert.deepEqual(state, INITIAL_STATE);
+  assert.deepStrictEqual(state, INITIAL_STATE);
   done();
 });

--- a/src/shared/redux/modules/__tests__/loading.test.js
+++ b/src/shared/redux/modules/__tests__/loading.test.js
@@ -1,24 +1,24 @@
 /* @flow */
-import assert from "power-assert";
+import assert from "assert";
 import reducer, { startLoading, stopLoading } from "../loading";
 
 test("loading: startLoading success", done => {
   const startLoadingAction = startLoading();
   const state = reducer(false, startLoadingAction);
-  assert(state === true);
+  assert.strictEqual(state, true);
   done();
 });
 
 test("loading: stopLoading success", done => {
   const stopLoadingAction = stopLoading();
   const state = reducer(true, stopLoadingAction);
-  assert(state === false);
+  assert.strictEqual(state, false);
   done();
 });
 
 test("loading: stopLoading success", done => {
   const stopLoadingAction = stopLoading();
   const state = reducer(false, stopLoadingAction);
-  assert(state === false);
+  assert.strictEqual(state, false);
   done();
 });

--- a/src/shared/redux/modules/__tests__/utils.test.js
+++ b/src/shared/redux/modules/__tests__/utils.test.js
@@ -4,7 +4,7 @@ import { createAsyncActionTypes } from "../utils";
 
 test("createAsyncActionTypes", done => {
   const actionTypes = createAsyncActionTypes("app/fetch");
-  assert.deepEqual(actionTypes, [
+  assert.deepStrictEqual(actionTypes, [
     "app/fetch/request",
     "app/fetch/success",
     "app/fetch/fail",


### PR DESCRIPTION
assertion周りの修正

- `assert.equal` / `assert.deepEqual` => `assert.strictEqual` / `assert.deepStrictEqual` へ修正
- `import assert from "power-assert"`  を  `import assert from "assert"`  へ修正
  - babelのpresetが入っているので `power-assert` をimportする必要はないはず。