### PR TITLE
Try fixing greenkeeper-lockfile-upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - <<: *restore
       - <<: *restore_lock
       - run: sudo npm install greenkeeper-lockfile@2 -g
-      - run: greenkeeper-lockfile-upload
+      - run: CI_PULL_REQUEST='' greenkeeper-lockfile-upload
       - <<: *save_lock
 
   install:
@@ -62,7 +62,7 @@ jobs:
       - <<: *restore_lock
       - run: case $CIRCLE_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac;
       - run: sudo npm install greenkeeper-lockfile@2 -g
-      - run: greenkeeper-lockfile-update
+      - run: CI_PULL_REQUEST='' greenkeeper-lockfile-update
       - <<: *save_lock
       - <<: *save
 


### PR DESCRIPTION
- https://github.com/greenkeeperio/greenkeeper-lockfile/issues/58 / https://github.com/greenkeeperio/greenkeeper-lockfile/commit/1030eeae9d5858c690ab6f2a83783c7ff3a482b8
によると、_.isEmpty(env.CI_PULL_REQUEST) の判定が狂うのが問題のようなので、そこを無理やり合わせるという修正です
- upload_lock は install の中でやっているので、不要そうに見えたので削除しました