### PR TITLE
JavaScript がダウンロードされず、実行される前の状況でもformだけは動作するようにした。

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10876,6 +10876,11 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
+    "is-redirectable-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-redirectable-url/-/is-redirectable-url-1.0.2.tgz",
+      "integrity": "sha512-Ls3c5IbueojmlqLB0xq9F94KcfMDSChcfProoZxh2SLoynBnf+hrQGz9xtnjiUyjg6k4SGuqFr6tHzuxDdRoyg=="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "fetchr": "^0.5.37",
     "fumble": "^0.1.3",
     "hoist-non-react-statics": "^3.0.0",
+    "is-redirectable-url": "^1.0.2",
     "jsonwebtoken": "^8.2.1",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.4",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -67,7 +67,7 @@ export default function renderer({
     app.use(asset.mount, express.static(asset.path));
   });
 
-  app.use(config.clientConfig.fetchr.xhrPath, apiGateway(config));
+  app.use(config.clientConfig.fetchr.xhrPath, apiGateway(config, app));
   app.use(compression());
   if (__ENABLE_OFFLOAD__) {
     app.use(offloadDetector(config.offload));

--- a/src/server/middlewares/apiGateway.js
+++ b/src/server/middlewares/apiGateway.js
@@ -3,14 +3,16 @@ import Fetchr from "fetchr";
 import debugFactory from "debug";
 import * as services from "server/services";
 import { verify } from "server/services/AccessToken";
+import requestAdapter from "./requestAdapter";
 
 const debug = debugFactory("app:server:middleware:apiGateway");
 
-export default function apiGateway(config: any) {
+export default function apiGateway(config: any, app: any) {
   Object.values(services).forEach((Service: any) => {
     const service = new Service(config);
     debug(`Registering sevice: ${service.name}`);
     Fetchr.registerService(makeServiceAdapter(service, config.auth.secret));
+    requestAdapter(service, app, config);
   });
 
   return (req: any, res: any, next: Function) => {

--- a/src/server/middlewares/reduxApp.js
+++ b/src/server/middlewares/reduxApp.js
@@ -19,6 +19,7 @@ import debugFactory from "debug";
 import createStore from "shared/redux/createStore";
 import { loadAllMasters as loadAllMastersAction } from "shared/redux/modules/masters";
 import { checkLogin } from "shared/redux/modules/auth";
+import { csrfAction } from "shared/redux/modules/csrf";
 import getRoutes from "shared/routes";
 import Html from "server/components/Html";
 import App from "server/components/App";
@@ -112,6 +113,7 @@ export default function createReduxApp(config) {
        * 初期表示に必要なデータをフェッチします。
        */
         timing.startTime("prefetch", "Prefetch onLoad");
+        store.dispatch(csrfAction(req.csrfToken()));
         return Promise.all([
           loadOnServer(renderProps, store),
           store.dispatch(checkLogin()).catch(() => null),

--- a/src/server/middlewares/requestAdapter.js
+++ b/src/server/middlewares/requestAdapter.js
@@ -1,0 +1,20 @@
+/* @flow */
+export default function makeRequestAdapter(
+  service: any,
+  app: any,
+  config: any,
+) {
+  if (!service.requestHandlers) {
+    return;
+  }
+
+  service.requestHandlers.forEach(handleName => {
+    const { path, get, post } = service[handleName](config);
+    if (get) {
+      app.get(path, get.bind(service));
+    }
+    if (post) {
+      app.post(path, post.bind(service));
+    }
+  });
+}

--- a/src/server/services/AgreedSample.js
+++ b/src/server/services/AgreedSample.js
@@ -15,8 +15,11 @@ export default class AgreedSample {
     this.pathname = "agreedsample";
   }
 
-  read(req: any, _resource: any, params: any = { status: 200 }, _config: any) {
-    const status = params.status;
+  read(req: any, _resource: any, params: any = {}, _config: any) {
+    const { status } = params;
+    if (!status) {
+      return read(this.axios, this.name, this.pathname, {});
+    }
     return read(this.axios, this.name, this.pathname, { status });
   }
 }

--- a/src/server/services/AgreedSample.js
+++ b/src/server/services/AgreedSample.js
@@ -15,8 +15,8 @@ export default class AgreedSample {
     this.pathname = "agreedsample";
   }
 
-  read(req: any, _resource: any, params: any, _config: any) {
-    const status = params.status || 200;
+  read(req: any, _resource: any, params: any = { status: 200 }, _config: any) {
+    const status = params.status;
     return read(this.axios, this.name, this.pathname, { status });
   }
 }

--- a/src/server/services/AgreedSample.js
+++ b/src/server/services/AgreedSample.js
@@ -16,6 +16,7 @@ export default class AgreedSample {
   }
 
   read(req: any, _resource: any, params: any, _config: any) {
-    return read(this.axios, this.name, this.pathname, params);
+    const status = params.status || 200;
+    return read(this.axios, this.name, this.pathname, { status });
   }
 }

--- a/src/server/services/utils.js
+++ b/src/server/services/utils.js
@@ -36,7 +36,7 @@ export function read(axios: any, name: string, pathname: string, query: any) {
           reason: error.response.data,
         });
       }
-      return rejectWith(fumble.create(500), {
+      return rejectWith(fumble.create(), {
         name,
         formattedUrl,
         reason: error.message,

--- a/src/shared/components/organisms/Login/LoginForm.js
+++ b/src/shared/components/organisms/Login/LoginForm.js
@@ -1,7 +1,6 @@
 /* @flow */
 import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 import { propTypes as formPropTypes, Field } from "redux-form";
 import { compose, onlyUpdateForPropTypes, setPropTypes } from "recompose";
 
@@ -28,22 +27,21 @@ const RenderInput = ({ input, meta: { dirty, error } }): $FIXME => (
 export default compose(
   onlyUpdateForPropTypes,
   setPropTypes({
-    globalFormDisabled: PropTypes.bool,
     ...formPropTypes,
   }),
 )(function LoginForm(props) {
   const {
-    globalFormDisabled,
     error,
     handleSubmit,
     reset,
     submitting,
     submitFailed,
     anyTouched,
+    csrf,
   } = props;
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit} method="POST">
       {error && <div>{error}</div>}
       {!error &&
         submitFailed &&
@@ -52,14 +50,12 @@ export default compose(
         <Field name="username" component={RenderInput} />
         <Field name="password" component={RenderInput} />
       </div>
+      <input type="hidden" name="_csrf" value={csrf} />
       <div>
-        <button type="submit" disabled={globalFormDisabled || submitting}>
+        <button type="submit" disabled={submitting}>
           Login
         </button>
-        <button
-          type="button"
-          disabled={globalFormDisabled || submitting}
-          onClick={reset}>
+        <button type="button" disabled={submitting} onClick={reset}>
           Clear
         </button>
       </div>

--- a/src/shared/components/organisms/Login/index.js
+++ b/src/shared/components/organisms/Login/index.js
@@ -3,7 +3,6 @@ import { reduxForm, isInvalid } from "redux-form";
 import { connect } from "react-redux";
 import { compose } from "recompose";
 import { sendAnalytics } from "react-redux-analytics";
-import { globalFormDisabledSelector } from "shared/redux/modules/reducer";
 import { login } from "shared/redux/modules/auth";
 import normalizeFormError from "shared/components/utils/normalizeFormError";
 import validate from "shared/validators/login";
@@ -16,7 +15,7 @@ import LoginForm from "./LoginForm";
 export default compose(
   connect(state => ({
     invalid: isInvalid("loginForm")(state),
-    globalFormDisabled: globalFormDisabledSelector(state),
+    csrf: state.app.csrf.token,
   })),
   sendAnalytics({
     ...siteSections("login", "top"),

--- a/src/shared/components/organisms/SearchForm/SearchForm.js
+++ b/src/shared/components/organisms/SearchForm/SearchForm.js
@@ -29,7 +29,6 @@ type Props = FormProps & {
   shouldAdjustScroll: boolean,
   linkURL: string,
   forceScrollTo: ?Object,
-  globalFormDisabled: boolean,
 };
 
 export default compose(
@@ -49,7 +48,6 @@ export default compose(
     shouldAdjustScroll: PropTypes.bool.isRequired,
     linkURL: PropTypes.string.isRequired,
     forceScrollTo: PropTypes.object,
-    globalFormDisabled: PropTypes.bool,
   }),
 )(function SearchForm(props: Props) {
   const {
@@ -68,7 +66,6 @@ export default compose(
     shouldAdjustScroll,
     linkURL,
     forceScrollTo,
-    globalFormDisabled,
   } = props;
 
   return (
@@ -84,7 +81,7 @@ export default compose(
                 component="input"
                 autoFocus={!count}
               />
-              <button type="submit" disabled={globalFormDisabled || submitting}>
+              <button type="submit" disabled={submitting}>
                 Search
               </button>
             </div>

--- a/src/shared/redux/modules/csrf.js
+++ b/src/shared/redux/modules/csrf.js
@@ -1,0 +1,35 @@
+/* @flow */
+import { createAction, handleAction, type Reducer } from "redux-actions";
+
+/**
+ * Action types
+ */
+const CSRF = "redux-proto/csrf";
+
+/**
+ * Action creators
+ */
+export const csrfAction = createAction(CSRF);
+
+/**
+ * Initial state
+ */
+
+export type State = {
+  token: ?string,
+};
+const INITIAL_STATE: State = {
+  token: null,
+};
+
+/**
+ * Reducer
+ */
+export default (handleAction(
+  CSRF,
+  (state, action) => ({
+    ...state,
+    token: action.payload,
+  }),
+  INITIAL_STATE,
+): Reducer<State, *>);

--- a/src/shared/redux/modules/reducer.js
+++ b/src/shared/redux/modules/reducer.js
@@ -8,6 +8,7 @@ import { analyticsReducer } from "react-redux-analytics";
 import agreedSample, { type State as AgreedSampleState } from "./agreedSample";
 import alert, { type State as AlertState } from "./alert";
 import auth, { type State as AuthState } from "./auth";
+import csrf, { type State as CsrfState } from "./csrf";
 import counter, { type State as CounterState } from "./counter";
 import loading, { type State as LoadingState } from "./loading";
 import masters, { type State as MastersState } from "./masters";
@@ -21,6 +22,7 @@ export type State = {
   app: {
     masters: MastersState,
     auth: AuthState,
+    csrf: CsrfState,
     counter: CounterState,
     alert: AlertState,
     loading: LoadingState,
@@ -44,6 +46,7 @@ export default combineReducers({
   app: combineReducers({
     masters,
     auth,
+    csrf,
     counter,
     alert,
     loading,


### PR DESCRIPTION
SSRであることをフルに活かして、 JavaScript がクライアントで動かなくてもformとしてはGET/POSTができて、実行でき、動作するようにserverサイド側の実装の修正とHTMLの実装修正を行った。

具体的には、 POST/GETをする際にはformのmethodを書くことと、リクエストを生でも受け付けてserviceが動くように修正した。

後ほどデモする。

また、新しいlibraryとして、 is-redirectable-url を追加した。これは、 server 側でopen redirector の脆弱性を突かれないようにするためのモジュールで、任意の場所にredirectしないようにするためのもの。

実装が多岐にわたってしまったので、後で口頭で解説後、問題なければマージする。