### PR TITLE
Retry of "Update recompose to the latest version 🚀"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,31 +38,18 @@ restore: &restore
   restore_cache:
     keys: 
       - code-{{ .Revision }}
+
 jobs:
-  build:
-    <<: *build_image
-    steps:
-      - checkout
-      - <<: *save
-
-
-  upload_lock:
-    <<: *build_image
-    steps:
-      - <<: *restore
-      - <<: *restore_lock
-      - run: sudo npm install greenkeeper-lockfile@2 -g
-      - run: greenkeeper-lockfile-upload
-      - <<: *save_lock
-
   install:
     <<: *build_image
     steps:
-      - <<: *restore
+      - checkout
       - <<: *restore_lock
       - run: case $CIRCLE_BRANCH in greenkeeper*) npm i;; *) npm ci;; esac;
-      - run: sudo npm install greenkeeper-lockfile@2 -g
-      - run: greenkeeper-lockfile-update
+        # TODO: This uses a workaround repository of greenkeeper-lockfile.
+        # Should be fixed when it gets working in the main repository.
+      - run: npx --package jasonLaster/greenkeeper-lockfile greenkeeper-lockfile-update
+      - run: npx --package jasonLaster/greenkeeper-lockfile greenkeeper-lockfile-upload
       - <<: *save_lock
       - <<: *save
 
@@ -117,13 +104,7 @@ workflows:
   version: 2
   exec:
     jobs:
-      - build
-      - install:
-          requires:
-            - build
-      - upload_lock:
-          requires:
-            - install
+      - install
       - lint:
           requires:
             - install

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-router-scroll": "^0.4.2",
     "react-universal-component": "^3.0.0",
     "react-virtualized": "^9.9.0",
-    "recompose": "0.27.1",
+    "recompose": "0.28.0",
     "redux": "^4.0.0",
     "redux-actions": "^2.3.0",
     "redux-async-loader": "^1.2.4",


### PR DESCRIPTION
- #102 の出し直しです
- #102 の CI で `Only running on first push of a new branch` というエラーが出ている ( https://circleci.com/gh/recruit-tech/redux-pluto/636 ) ので、PR 内の最初の commit でしか有効で無いように見えるため、greenkeeper の commit と workaround の commit を squash して 1 commit にしてみました