### PR TITLE
fix(client): remove replace current url and add history

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -19,13 +19,6 @@ const history = syncHistoryWithStore(browserHistory, store, {
 });
 const root = document.getElementById("root");
 
-// 初回表示直後に、表示している画面と同じURLのリンクをクリックした場合にPUSHステートされてしまう現象の回避策。
-// 通常、現在表示している画面と同じURLへのPUSHはHistoryモジュールによりREPLACEに置換される。
-// https://github.com/ReactTraining/history/blob/57d24e6/modules/createHistory.js#L105
-// しかし、初回表示時点ではcurrentLocationが未設定のためにprevPathが得られず、PUSHされてしまう。
-// これを回避するため、ここで現在のロケーションにREPLACEすることでcurrentLocationを設定する。
-history.replace(history.getCurrentLocation());
-
 const locationSubscriber = createLocationSubscriber(store);
 history.listen(location => {
   // At the moment, we do not use page stack functionality of react-redux-analytics.


### PR DESCRIPTION
https://github.com/recruit-tech/redux-pluto/issues/110

原因は初回に `history.replace(history.getCurrentLocation());` することで毎回スクロール位置が[0, 0]に戻されていたために発生。元々page scopeのために、replace, pushの動きを追っているが、同じpathにリクエストを投げるとpage scope上は前回のscopeに戻ってその後再取得されるため、一時的にrenderが発生してしまう問題に対して、historyを無理矢理初回に変更させる事で修正していたが、ここが原因でスクロール回帰が死んでいた。

page scopeを使わずにapp scopeでやるケースのが多いため、スクロール回帰を復活させる。