### PR TITLE
upload_lock ジョブにも greenkeeper の git user 情報をセットする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,12 @@ restore: &restore
 jobs:
   upload_lock:
     <<: *build_image
+    # workaround for greenkeeper-lockfile-upload
+    environment:
+      GIT_AUTHOR_NAME: greenkeeperio-bot
+      GIT_AUTHOR_EMAIL: support@greenkeeper.io
+      GIT_COMMITTER_NAME: greenkeeperio-bot
+      GIT_COMMITTER_EMAIL: support@greenkeeper.io
     steps:
       - <<: *restore
       - <<: *restore_lock


### PR DESCRIPTION
- `upload_lock` ジョブ内の greenkeeper-lockfile-upload コマンド実行時に `git stash` が実行される場合があり、その際、git のユーザー情報がない場合にエラーとなってしまうため、`upload_lock` ジョブに対しても greenkeeper のユーザー情報を git にセットする、という修正です

参考: #153