### PR TITLE
mailto:, tel:,に誤って個人情報が含まれる可能性への考慮

### DIFF
--- a/src/client/analytics/config/dev.js
+++ b/src/client/analytics/config/dev.js
@@ -4,7 +4,8 @@ module.exports = {
   s_account: "rcrtreduxprotodev",
   addHostNameToLinkInternalFilters: true,
   s_code: {
-    linkInternalFilters: "javascript:,r.recruit.co.jp",
+    linkInternalFilters: "javascript:mailto:,tel:,r.recruit.co.jp",
+    trackInlineStats: false,
     // linkTrackVars: '',
     visitorNamespace: "recruit",
     trackingServer: "recruit.112.2o7.net",

--- a/src/client/analytics/config/prod.js
+++ b/src/client/analytics/config/prod.js
@@ -4,7 +4,8 @@ module.exports = {
   s_account: "rcrtreduxprotoprd",
   addHostNameToLinkInternalFilters: true,
   s_code: {
-    linkInternalFilters: "javascript:,r.recruit.co.jp",
+    linkInternalFilters: "javascript:mailto:,tel:,r.recruit.co.jp",
+    trackInlineStats: false,
     // linkTrackVars: '',
     visitorNamespace: "recruit",
     trackingServer: "recruit.112.2o7.net",


### PR DESCRIPTION
以下の２点への対応
(1) mailto:, tel:,をs.linkInternalFiltersに追加し、ExternalLinkTrackの計測対象外とする。
(2) s.trackInlineStatsをfalseにする
