### PR TITLE
linkInternalFiltersの記法に誤りがあったので修正

### DIFF
--- a/src/client/analytics/config/dev.js
+++ b/src/client/analytics/config/dev.js
@@ -4,7 +4,7 @@ module.exports = {
   s_account: "rcrtreduxprotodev",
   addHostNameToLinkInternalFilters: true,
   s_code: {
-    linkInternalFilters: "javascript:mailto:,tel:,r.recruit.co.jp",
+    linkInternalFilters: "javascript:,mailto:,tel:,r.recruit.co.jp",
     trackInlineStats: false,
     // linkTrackVars: '',
     visitorNamespace: "recruit",

--- a/src/client/analytics/config/prod.js
+++ b/src/client/analytics/config/prod.js
@@ -4,7 +4,7 @@ module.exports = {
   s_account: "rcrtreduxprotoprd",
   addHostNameToLinkInternalFilters: true,
   s_code: {
-    linkInternalFilters: "javascript:mailto:,tel:,r.recruit.co.jp",
+    linkInternalFilters: "javascript:,mailto:,tel:,r.recruit.co.jp",
     trackInlineStats: false,
     // linkTrackVars: '',
     visitorNamespace: "recruit",


### PR DESCRIPTION
linkInternalFiltersの設定を
`javascript:,mailto:,tel:,r.recruit.co.jp`
であるべきところ、
`javascript:mailto:,tel:,r.recruit.co.jp`
とカンマ区切りが抜け漏れてしまっていたので再度修正。