### PR TITLE
redux-devtool が表示されない不具合の解消

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,6 +13,8 @@ import analyticsOptions from "../shared/redux/analytics/options";
 import App from "./components/App";
 import siteCatalystOptions from "./analytics";
 
+const isDevToolVisible = __DEVELOPMENT__ && !__MOCK_BUILD__;
+
 const store = configStore();
 const history = syncHistoryWithStore(browserHistory, store, {
   adjustUrlOnReplay: __DEVELOPMENT__,
@@ -25,8 +27,6 @@ history.listen(location => {
   // console.log(location);
   locationSubscriber.notify(location, "replace");
 });
-
-const isDevToolVisible = __DEVELOPMENT__ && !__MOCK_BUILD__;
 
 renderApp().then(() => {
   if (isDevToolVisible) {


### PR DESCRIPTION
configStore()　内で isDevToolVisible を参照しようとするも値が取れないため
devtool がうまく設定されなくなっていた不具合を解消致しました。