### PR TITLE
Fix - injectGlobal -> createGlobalStyle

### DIFF
--- a/src/server/components/App.js
+++ b/src/server/components/App.js
@@ -3,11 +3,11 @@ import React from "react";
 import { type Store } from "redux";
 import { Provider } from "react-redux";
 import RouterContext from "react-router/lib/RouterContext";
-import { injectGlobal } from "styled-components";
+import { createGlobalStyle } from "styled-components";
 import { type State } from "../../shared/redux/modules/reducer";
 
 /* eslint no-unused-expressions: 0 */
-injectGlobal`
+createGlobalStyle`
   * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
```
TypeError: styled_components__WEBPACK_IMPORTED_MODULE_3__.injectGlobal is not a function
    at Module../src/server/components/App.js (/Users/01012987/Development/redux-pluto/build/server/webpack:/src/server/components/App.js:10:14)
    at __webpack_require__ (/Users/01012987/Development/redux-pluto/build/server/webpack:/webpack/bootstrap:25:1)
    at Module../src/server/middlewares/reduxApp.js (/Users/01012987/Development/redux-pluto/build/server/main.js:7618:74)
    at __webpack_require__ (/Users/01012987/Development/redux-pluto/build/server/webpack:/webpack/bootstrap:25:1)
    at Module../src/server/middlewares/index.js (/Users/01012987/Development/redux-pluto/build/server/main.js:7526:67)
    at __webpack_require__ (/Users/01012987/Development/redux-pluto/build/server/webpack:/webpack/bootstrap:25:1)
    at Module../src/server/index.js (/Users/01012987/Development/redux-pluto/build/server/main.js:7358:71)
    at __webpack_require__ (/Users/01012987/Development/redux-pluto/build/server/webpack:/webpack/bootstrap:25:1)
    at Object.0 (/Users/01012987/Development/redux-pluto/build/server/main.js:13225:18)
    at __webpack_require__ (/Users/01012987/Development/redux-pluto/build/server/webpack:/webpack/bootstrap:25:1)
```
上記のエラーになっていたのを修正しました。


<img width="966" alt="2018-10-24 14 45 33" src="https://user-images.githubusercontent.com/1264729/47408724-748b7780-d79b-11e8-84bb-d73cc655ab92.png">
