### PR TITLE
fix: undefined mock_build env in prod

### DIFF
--- a/src/webpack/dev.client.config.js
+++ b/src/webpack/dev.client.config.js
@@ -87,7 +87,7 @@ module.exports = {
       __SERVER__: false,
       __DEVELOPMENT__: true,
       __DEVTOOLS__: true,
-      __MOCK_BUILD__: process.env.MOCK_BUILD,
+      __MOCK_BUILD__: !!process.env.MOCK_BUILD,
       __DISABLE_SSR__: !!process.env.DISABLE_SSR,
       __REPORTSUITE_ENV__: JSON.stringify("dev"),
     }),

--- a/src/webpack/prod.client.config.js
+++ b/src/webpack/prod.client.config.js
@@ -74,6 +74,7 @@ module.exports = {
       __SERVER__: false,
       __DEVELOPMENT__: false,
       __DEVTOOLS__: false,
+      __MOCK_BUILD__: !!process.env.MOCK_BUILD,
       __DISABLE_SSR__: !!process.env.DISABLE_SSR,
       __REPORTSUITE_ENV__: JSON.stringify(process.env.RS_ENV),
     }),


### PR DESCRIPTION
production buildでMOCK_BUILD is undefinedになってしまうため。