### PR TITLE
開発中の差分ビルドの高速化

### DIFF
--- a/src/webpack/dev.client.config.js
+++ b/src/webpack/dev.client.config.js
@@ -16,7 +16,7 @@ module.exports = {
 
   target: "web",
 
-  devtool: "inline-source-map",
+  devtool: "eval-cheap-module-source-map",
 
   context: rootDir,
 
@@ -72,10 +72,7 @@ module.exports = {
 
   optimization: {
     noEmitOnErrors: true,
-    splitChunks: {
-      chunks: "all",
-      name: "bootstrap",
-    },
+    splitChunks: false,
   },
 
   plugins: [

--- a/src/webpack/dev.server.config.js
+++ b/src/webpack/dev.server.config.js
@@ -33,7 +33,7 @@ module.exports = {
 
   target: "node",
 
-  devtool: "source-map",
+  devtool: "eval-source-map",
 
   entry: [path.resolve(rootDir, "src/server/index.js")],
 


### PR DESCRIPTION
## modify devtools in webpack

<img width="706" alt="2018-11-22 12 54 13" src="https://user-images.githubusercontent.com/9594376/48883577-c808e800-ee63-11e8-8e72-a3deea5cccd6.png">

## disable split chunk in development

無駄にchunkを開発中に分けているのをやめました