### PR TITLE
Add isSafePath validation for prevent path traversal

### DIFF
--- a/src/server/services/__tests__/AgreedService.read.test.ts
+++ b/src/server/services/__tests__/AgreedService.read.test.ts
@@ -15,3 +15,17 @@ test("AgreedService: read success", async () => {
   const result = await agreedService.read();
   assert.deepStrictEqual(result, getText.response.values);
 });
+
+test("AgreedService: forbidden path traversal", async done => {
+  const agreedService: any = new AgreedService(
+    config,
+    "foo",
+    "/something/../agreedsample",
+    "foo",
+  );
+  agreedService.read().then(done.fail, (e: any) => {
+    assert.strictEqual(e.statusCode, 403);
+    assert.strictEqual(e.message, "Forbidden");
+    done();
+  });
+});

--- a/src/server/services/__tests__/utils.isSafePath.test.ts
+++ b/src/server/services/__tests__/utils.isSafePath.test.ts
@@ -1,0 +1,24 @@
+import assert from "assert";
+import { isSafePath } from "../utils";
+
+test("utils: isSafePath", () => {
+  const testCases = [
+    { pathname: "/", expected: true },
+    { pathname: ".", expected: true },
+    { pathname: "foo", expected: true },
+    { pathname: "/foo", expected: true },
+    { pathname: "foo/", expected: true },
+    { pathname: "/foo/", expected: true },
+    { pathname: "foo/bar", expected: true },
+    { pathname: "", expected: false },
+    { pathname: "foo//", expected: false },
+    { pathname: "//foo", expected: false },
+    { pathname: "foo//bar", expected: false },
+    { pathname: "foo/./bar", expected: false },
+    { pathname: "foo/../bar", expected: false },
+  ];
+  testCases.forEach(testCase => {
+    const actual = isSafePath(testCase.pathname);
+    assert.strictEqual(actual, testCase.expected);
+  });
+});

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -2,6 +2,7 @@ import { format as formatUrl } from "url";
 import fumble from "fumble";
 import debugFactory from "debug";
 import { AxiosInstance } from "axios";
+import path from "path";
 
 const debug = debugFactory("app:server:services");
 
@@ -13,6 +14,14 @@ export function read(
 ) {
   const formattedUrl = formatUrl({ pathname, query });
   debug(`[${name}]: GET ${formattedUrl}`);
+
+  if (!isSafePath(pathname)) {
+    return rejectWith(fumble.http.create(403), {
+      name,
+      formattedUrl,
+      reason: "unsafe pathname",
+    });
+  }
 
   return axios.get(formattedUrl).then(
     response => {
@@ -93,6 +102,14 @@ export function create(
   const formattedUrl = formatUrl({ pathname, query });
   debug(`[${name}]: POST ${formattedUrl} with body: ${JSON.stringify(body)}`);
 
+  if (!isSafePath(pathname)) {
+    return rejectWith(fumble.http.create(403), {
+      name,
+      formattedUrl,
+      reason: "unsafe pathname",
+    });
+  }
+
   return axios.post(formattedUrl, body, { headers }).then(
     response => response.data,
     error => {
@@ -116,4 +133,8 @@ export function rejectWith(error: any, output: any = {}) {
   error.output = output;
   debug(error);
   return Promise.reject(error);
+}
+
+export function isSafePath(pathname: string) {
+  return path.normalize(pathname) == pathname;
 }

--- a/src/shared/redux/middleware/apiErrorMiddleware.ts
+++ b/src/shared/redux/middleware/apiErrorMiddleware.ts
@@ -36,6 +36,8 @@ export default function apiErrorMiddleware() {
           const { locationBeforeTransitions } = routing;
           const { pathname } = locationBeforeTransitions;
           dispatch(replace(`/login?location=${pathname}`));
+        } else if (statusCode === 403) {
+          dispatch(showAlert("無効なリクエストが発生しました。"));
         } else if (statusCode === 404) {
           dispatch(showAlert("何も見つかりませんでした。"));
         }


### PR DESCRIPTION
## 概要
パストラバーサル対策を目的としたpathnameのバリデーションをread(), create()に追加する。

## 動作
pathnameにpath.normalize()をかけた際、元と異なる文字列となった場合にリクエストを無効化する。  
path.normalize()によって異なる文字列となるpathnameは以下のようなものである。

```javascript
path.normalize('aaa/../bbb/ccc') → 'bbb/ccc'

path.normalize('aaa/./bbb/ccc') → 'aaa/bbb/ccc'

path.normalize('aaa//') → 'aaa/'

path.normalize('//aaa') → '/aaa'

path.normalize('') → '.'
```

リクエストが無効化された際、レスポンスとしては `403 Forbidden` を返す。