### PR TITLE
Add formatPathname function for prevent path manipulation

### DIFF
--- a/src/server/services/__tests__/utils.formatPathname.test.ts
+++ b/src/server/services/__tests__/utils.formatPathname.test.ts
@@ -1,92 +1,46 @@
 import assert from "assert";
 import { formatPathname } from "../utils";
 
-test("utils: formatPathname success", () => {
+test("utils: formatPathname", () => {
   const testCases = [
-    { pathname: "", args: [], expected: "" },
-    { pathname: "?", args: ["foo"], expected: "foo" },
-    { pathname: "/", args: [], expected: "/" },
-    { pathname: "/foo", args: [], expected: "/foo" },
-    { pathname: "/foo/?", args: ["bar"], expected: "/foo/bar" },
-    { pathname: "/foo/?/baz", args: ["bar"], expected: "/foo/bar/baz" },
-    { pathname: "/foo/?", args: [null], expected: "/foo/null" },
-    { pathname: "/foo/?", args: [123], expected: "/foo/123" },
-    { pathname: "/foo/?", args: ["."], expected: "/foo/%2E" },
-    { pathname: "/foo/?", args: [".."], expected: "/foo/%2E%2E" },
-    { pathname: "/foo/?", args: ["..."], expected: "/foo/..." },
+    { pathname: "", params: [], expected: "" },
+    { pathname: "?", params: ["foo"], expected: "foo" },
+    { pathname: "/", params: [], expected: "/" },
+    { pathname: "/foo", params: [], expected: "/foo" },
+    { pathname: "/foo/?", params: ["bar"], expected: "/foo/bar" },
+    { pathname: "/foo/?/baz", params: ["bar"], expected: "/foo/bar/baz" },
+    { pathname: "/foo/?", params: [null], expected: "/foo/null" },
+    { pathname: "/foo/?", params: [123], expected: "/foo/123" },
+    { pathname: "/foo/?", params: ["."], expected: "/foo/%2E" },
+    { pathname: "/foo/?", params: [".."], expected: "/foo/%2E%2E" },
+    { pathname: "/foo/?", params: ["..."], expected: "/foo/..." },
     {
       pathname: "/foo/?",
-      args: ["!@#$%^&*()_+=-`~¥\\][{}|';:\"/.,<>?"],
+      params: ["!@#$%^&*()_+=-`~¥\\][{}|';:\"/.,<>?"],
       expected:
         "/foo/!%40%23%24%25%5E%26*()_%2B%3D-%60~%C2%A5%5C%5D%5B%7B%7D%7C'%3B%3A%22%2F.%2C%3C%3E%3F",
     },
     {
       pathname: "/foo/?/bar/?/baz/?/hoge/?/fuga/?/",
-      args: ["piyo?", null, 123, "..", {}],
+      params: ["piyo?", null, 123, "..", {}],
       expected:
         "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/%5Bobject%20Object%5D/",
     },
+    { pathname: "/?", params: [], expected: "/?" },
+    { pathname: "/", params: ["foo"], expected: "/" },
+    { pathname: "/?", params: ["foo", 123, "..", "!@#$"], expected: "/foo" },
+    { pathname: "/?/?/?/?", params: ["foo"], expected: "/foo/?/?/?" },
+    { pathname: "/?", params: [""], expected: "/?" },
+    { pathname: "/foo/?/bar", params: [""], expected: "/foo/?/bar" },
+    { pathname: "/foo/?/bar/?", params: [[], []], expected: "/foo/?/bar/?" },
+    {
+      pathname: "/?/?/?/?",
+      params: ["", "foo", "bar", "baz"],
+      expected: "/?/foo/bar/baz",
+    },
   ];
   testCases.forEach(testCase => {
-    let actual = formatPathname(testCase.pathname, testCase.args);
+    let actual = formatPathname(testCase.pathname, testCase.params);
     assert.strictEqual(actual, testCase.expected);
-  });
-});
-
-test("utils: formatPathname error", () => {
-  const testCases = [
-    {
-      pathname: "/?",
-      args: [],
-      expectedErr: {
-        message: "number of placeholders should be same to args length",
-      },
-    },
-    {
-      pathname: "/",
-      args: ["foo"],
-      expectedErr: {
-        message: "number of placeholders should be same to args length",
-      },
-    },
-    {
-      pathname: "/?",
-      args: ["foo", 123, "..", "!@#$"],
-      expectedErr: {
-        message: "number of placeholders should be same to args length",
-      },
-    },
-    {
-      pathname: "/?/?/?/?",
-      args: ["foo"],
-      expectedErr: {
-        message: "number of placeholders should be same to args length",
-      },
-    },
-    {
-      pathname: "/?",
-      args: [""],
-      expectedErr: { message: "invalid pathname argument" },
-    },
-    {
-      pathname: "/foo/?/bar",
-      args: [""],
-      expectedErr: { message: "invalid pathname argument" },
-    },
-    {
-      pathname: "/foo/?/bar/?",
-      args: [[], []],
-      expectedErr: { message: "invalid pathname argument" },
-    },
-    {
-      pathname: "/?/?/?/?",
-      args: ["", "foo", "bar", "baz"],
-      expectedErr: { message: "invalid pathname argument" },
-    },
-  ];
-  testCases.forEach(testCase => {
-    assert.throws(() => {
-      formatPathname(testCase.pathname, testCase.args);
-    }, testCase.expectedErr);
   });
 });

--- a/src/server/services/__tests__/utils.formatPathname.test.ts
+++ b/src/server/services/__tests__/utils.formatPathname.test.ts
@@ -21,9 +21,10 @@ test("utils: formatPathname success", () => {
         "/foo/!%40%23%24%25%5E%26*()_%2B%3D-%60~%C2%A5%5C%5D%5B%7B%7D%7C'%3B%3A%22%2F.%2C%3C%3E%3F",
     },
     {
-      pathname: "/foo/?/bar/?/baz/?/hoge/?/fuga/",
-      args: ["piyo?", null, 123, ".."],
-      expected: "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/",
+      pathname: "/foo/?/bar/?/baz/?/hoge/?/fuga/?/",
+      args: ["piyo?", null, 123, "..", {}],
+      expected:
+        "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/%5Bobject%20Object%5D/",
     },
   ];
   testCases.forEach(testCase => {
@@ -70,6 +71,11 @@ test("utils: formatPathname error", () => {
     {
       pathname: "/foo/?/bar",
       args: [""],
+      expectedErr: { message: "invalid pathname argument" },
+    },
+    {
+      pathname: "/foo/?/bar/?",
+      args: [[], []],
       expectedErr: { message: "invalid pathname argument" },
     },
     {

--- a/src/server/services/__tests__/utils.formatPathname.test.ts
+++ b/src/server/services/__tests__/utils.formatPathname.test.ts
@@ -26,21 +26,21 @@ test("utils: formatPathname", () => {
       expected:
         "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/%5Bobject%20Object%5D/",
     },
-    { pathname: "/?", params: [], expected: "/null" },
+    { pathname: "/?", params: [], expected: "/!(MISSING)" },
     { pathname: "/", params: ["foo"], expected: "/" },
     { pathname: "/?", params: ["foo", 123, "..", "!@#$"], expected: "/foo" },
-    { pathname: "/?/?/?/?", params: ["foo"], expected: "/foo/null/null/null" },
-    { pathname: "/?", params: [""], expected: "/null" },
-    { pathname: "/foo/?/bar", params: [""], expected: "/foo/null/bar" },
+    { pathname: "/?/?/?/?", params: ["foo"], expected: "/foo/!(MISSING)/!(MISSING)/!(MISSING)" },
+    { pathname: "/?", params: [""], expected: "/!(EMPTY)" },
+    { pathname: "/foo/?/bar", params: [""], expected: "/foo/!(EMPTY)/bar" },
     {
       pathname: "/foo/?/bar/?",
       params: [[], []],
-      expected: "/foo/null/bar/null",
+      expected: "/foo/!(EMPTY)/bar/!(EMPTY)",
     },
     {
       pathname: "/?/?/?/?",
       params: ["", "foo", "bar", "baz"],
-      expected: "/null/foo/bar/baz",
+      expected: "/!(EMPTY)/foo/bar/baz",
     },
   ];
   testCases.forEach(testCase => {

--- a/src/server/services/__tests__/utils.formatPathname.test.ts
+++ b/src/server/services/__tests__/utils.formatPathname.test.ts
@@ -26,17 +26,21 @@ test("utils: formatPathname", () => {
       expected:
         "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/%5Bobject%20Object%5D/",
     },
-    { pathname: "/?", params: [], expected: "/?" },
+    { pathname: "/?", params: [], expected: "/null" },
     { pathname: "/", params: ["foo"], expected: "/" },
     { pathname: "/?", params: ["foo", 123, "..", "!@#$"], expected: "/foo" },
-    { pathname: "/?/?/?/?", params: ["foo"], expected: "/foo/?/?/?" },
-    { pathname: "/?", params: [""], expected: "/?" },
-    { pathname: "/foo/?/bar", params: [""], expected: "/foo/?/bar" },
-    { pathname: "/foo/?/bar/?", params: [[], []], expected: "/foo/?/bar/?" },
+    { pathname: "/?/?/?/?", params: ["foo"], expected: "/foo/null/null/null" },
+    { pathname: "/?", params: [""], expected: "/null" },
+    { pathname: "/foo/?/bar", params: [""], expected: "/foo/null/bar" },
+    {
+      pathname: "/foo/?/bar/?",
+      params: [[], []],
+      expected: "/foo/null/bar/null",
+    },
     {
       pathname: "/?/?/?/?",
       params: ["", "foo", "bar", "baz"],
-      expected: "/?/foo/bar/baz",
+      expected: "/null/foo/bar/baz",
     },
   ];
   testCases.forEach(testCase => {

--- a/src/server/services/__tests__/utils.formatPathname.test.ts
+++ b/src/server/services/__tests__/utils.formatPathname.test.ts
@@ -1,0 +1,86 @@
+import assert from "assert";
+import { formatPathname } from "../utils";
+
+test("utils: formatPathname success", () => {
+  const testCases = [
+    { pathname: "", args: [], expected: "" },
+    { pathname: "?", args: ["foo"], expected: "foo" },
+    { pathname: "/", args: [], expected: "/" },
+    { pathname: "/foo", args: [], expected: "/foo" },
+    { pathname: "/foo/?", args: ["bar"], expected: "/foo/bar" },
+    { pathname: "/foo/?/baz", args: ["bar"], expected: "/foo/bar/baz" },
+    { pathname: "/foo/?", args: [null], expected: "/foo/null" },
+    { pathname: "/foo/?", args: [123], expected: "/foo/123" },
+    { pathname: "/foo/?", args: ["."], expected: "/foo/%2E" },
+    { pathname: "/foo/?", args: [".."], expected: "/foo/%2E%2E" },
+    { pathname: "/foo/?", args: ["..."], expected: "/foo/..." },
+    {
+      pathname: "/foo/?",
+      args: ["!@#$%^&*()_+=-`~¥\\][{}|';:\"/.,<>?"],
+      expected:
+        "/foo/!%40%23%24%25%5E%26*()_%2B%3D-%60~%C2%A5%5C%5D%5B%7B%7D%7C'%3B%3A%22%2F.%2C%3C%3E%3F",
+    },
+    {
+      pathname: "/foo/?/bar/?/baz/?/hoge/?/fuga/",
+      args: ["piyo?", null, 123, ".."],
+      expected: "/foo/piyo%3F/bar/null/baz/123/hoge/%2E%2E/fuga/",
+    },
+  ];
+  testCases.forEach(testCase => {
+    let actual = formatPathname(testCase.pathname, testCase.args);
+    assert.strictEqual(actual, testCase.expected);
+  });
+});
+
+test("utils: formatPathname error", () => {
+  const testCases = [
+    {
+      pathname: "/?",
+      args: [],
+      expectedErr: {
+        message: "number of placeholders should be same to args length",
+      },
+    },
+    {
+      pathname: "/",
+      args: ["foo"],
+      expectedErr: {
+        message: "number of placeholders should be same to args length",
+      },
+    },
+    {
+      pathname: "/?",
+      args: ["foo", 123, "..", "!@#$"],
+      expectedErr: {
+        message: "number of placeholders should be same to args length",
+      },
+    },
+    {
+      pathname: "/?/?/?/?",
+      args: ["foo"],
+      expectedErr: {
+        message: "number of placeholders should be same to args length",
+      },
+    },
+    {
+      pathname: "/?",
+      args: [""],
+      expectedErr: { message: "invalid pathname argument" },
+    },
+    {
+      pathname: "/foo/?/bar",
+      args: [""],
+      expectedErr: { message: "invalid pathname argument" },
+    },
+    {
+      pathname: "/?/?/?/?",
+      args: ["", "foo", "bar", "baz"],
+      expectedErr: { message: "invalid pathname argument" },
+    },
+  ];
+  testCases.forEach(testCase => {
+    assert.throws(() => {
+      formatPathname(testCase.pathname, testCase.args);
+    }, testCase.expectedErr);
+  });
+});

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -139,29 +139,26 @@ export function isSafePath(pathname: string) {
   return path.normalize(pathname) == pathname;
 }
 
-export function formatPathname(pathname: string, args: Array<any>): string {
-  const placeholderNum = (pathname.match(/\?/g) || []).length;
-  if (placeholderNum != (args || []).length) {
-    throw new TypeError("number of placeholders should be same to args length");
-  }
-  if (placeholderNum == 0) {
-    return pathname;
-  }
-
-  let result = "";
-  let lastIndex = 0;
-
-  args.forEach(arg => {
-    let encodedArg = encodeURIComponent(arg);
-    if (encodedArg == "") {
-      throw new TypeError("invalid pathname argument");
-    }
-    if (encodedArg == "." || encodedArg == "..") {
-      encodedArg = encodedArg.replace(/\./g, "%2E");
-    }
-    const nextIndex = pathname.indexOf("?", lastIndex);
-    result += pathname.slice(lastIndex, nextIndex) + encodedArg;
-    lastIndex = nextIndex + 1;
-  });
-  return result + pathname.slice(lastIndex);
+export function formatPathname(pathname: string, params: Array<any>): string {
+  const paramsIter = params[Symbol.iterator]();
+  return pathname
+    .split("/")
+    .map(part => {
+      if (part != "?") {
+        return part;
+      }
+      const param = paramsIter.next();
+      if (param.done) {
+        return part;
+      }
+      const encodedParam = encodeURIComponent(param.value);
+      if (encodedParam == "") {
+        return part;
+      }
+      if (encodedParam == "." || encodedParam == "..") {
+        return encodedParam.replace(/\./g, "%2E");
+      }
+      return encodedParam;
+    })
+    .join("/");
 }

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -152,10 +152,10 @@ export function formatPathname(pathname: string, args: Array<any>): string {
   let lastIndex = 0;
 
   args.forEach(arg => {
-    if (arg == "") {
+    let encodedArg = encodeURIComponent(arg);
+    if (encodedArg == "") {
       throw new TypeError("invalid pathname argument");
     }
-    let encodedArg = encodeURIComponent(arg);
     if (encodedArg == "." || encodedArg == "..") {
       encodedArg = encodedArg.replace(/\./g, "%2E");
     }

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -138,3 +138,30 @@ export function rejectWith(error: any, output: any = {}) {
 export function isSafePath(pathname: string) {
   return path.normalize(pathname) == pathname;
 }
+
+export function formatPathname(pathname: string, args: Array<any>): string {
+  const placeholderNum = (pathname.match(/\?/g) || []).length;
+  if (placeholderNum != (args || []).length) {
+    throw new TypeError("number of placeholders should be same to args length");
+  }
+  if (placeholderNum == 0) {
+    return pathname;
+  }
+
+  let result = "";
+  let lastIndex = 0;
+
+  args.forEach(arg => {
+    if (arg == "") {
+      throw new TypeError("invalid pathname argument");
+    }
+    let encodedArg = encodeURIComponent(arg);
+    if (encodedArg == "." || encodedArg == "..") {
+      encodedArg = encodedArg.replace(/\./g, "%2E");
+    }
+    const nextIndex = pathname.indexOf("?", lastIndex);
+    result += pathname.slice(lastIndex, nextIndex) + encodedArg;
+    lastIndex = nextIndex + 1;
+  });
+  return result + pathname.slice(lastIndex);
+}

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -149,11 +149,11 @@ export function formatPathname(pathname: string, params: Array<any>): string {
       }
       const param = paramsIter.next();
       if (param.done) {
-        return part;
+        return "null";
       }
       const encodedParam = encodeURIComponent(param.value);
       if (encodedParam === "") {
-        return part;
+        return "null";
       }
       if (encodedParam === "." || encodedParam === "..") {
         return encodedParam.replace(/\./g, "%2E");

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -149,11 +149,11 @@ export function formatPathname(pathname: string, params: Array<any>): string {
       }
       const param = paramsIter.next();
       if (param.done) {
-        return "null";
+        return "!(MISSING)";
       }
       const encodedParam = encodeURIComponent(param.value);
       if (encodedParam === "") {
-        return "null";
+        return "!(EMPTY)";
       }
       if (encodedParam === "." || encodedParam === "..") {
         return encodedParam.replace(/\./g, "%2E");

--- a/src/server/services/utils.ts
+++ b/src/server/services/utils.ts
@@ -144,7 +144,7 @@ export function formatPathname(pathname: string, params: Array<any>): string {
   return pathname
     .split("/")
     .map(part => {
-      if (part != "?") {
+      if (part !== "?") {
         return part;
       }
       const param = paramsIter.next();
@@ -152,10 +152,10 @@ export function formatPathname(pathname: string, params: Array<any>): string {
         return part;
       }
       const encodedParam = encodeURIComponent(param.value);
-      if (encodedParam == "") {
+      if (encodedParam === "") {
         return part;
       }
-      if (encodedParam == "." || encodedParam == "..") {
+      if (encodedParam === "." || encodedParam === "..") {
         return encodedParam.replace(/\./g, "%2E");
       }
       return encodedParam;


### PR DESCRIPTION
## 概要
API呼び出し時の不正なパス操作対策として、安全にpathnameへパラメータを埋め込む関数formatPathnameを追加する。  
SQLのプレースホルダと似た使用感となるようにしている。

## 動作

formatPathnameは2つの引数を取る。

- pathname: pathnameのテンプレート
- params: パラメータ配列

```javascript
function formatPathname(pathname: string, params: Array<any>): string
```

pathname中に `?` を含めると、その部分がプレースホルダとして扱われる。  
paramsにはプレースホルダを置き換えるデータを指定する。

```javascript
formatPathname("/foo/?/bar/?", [1001, "hoge"]) → "/foo/1001/bar/hoge"
```

内部的にパラメータへencodeURIComponentをかけているので、基本的に記号はURIエンコードされる。

```javascript
formatPathname("/foo/?/bar/?", ["@#$", "../../../hoge"]) → "/foo/%40%23%24/bar/..%2F..%2F..%2Fhoge"
```

ただし、encodeURIComponentは `.`  をエンコードしないため、パラメータが `.` と `..` のときはパス構造が壊れないように別途URLエンコードする。

```javascript
formatPathname("/foo/?/bar/?", [".", ".."]) → "/foo/%2E/bar/%2E%2E"
```

## 引数に問題があった場合

エラーメッセージは `!(MESSAGE)` の書式でパス内に埋め込まれる。

パラメータに空文字が含まれていた場合、`foo/?/bar` → `foo//bar` → `foo/bar` となってパス構造が壊れてしまうため `!(EMPTY)` とする。

```javascript
formatPathname("/foo/?/bar/?", ["", "hoge"]) → "/foo/!(EMPTY)/bar/hoge"
```

プレースホルダの数とパラメータの数が異なる場合は不足分を `!(MISSING)` とする。

```javascript
formatPathname("/foo/?/bar/?", ["hoge"]) → "/foo/hoge/bar/!(MISSING)"
```