### PR TITLE
chore: Remove "npm audit" job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,12 +86,6 @@ jobs:
       - <<: *restore
       - <<: *restore_lock
       - run: npm run checksize
-  audit:
-    <<: *build_image
-    steps:
-      - <<: *restore
-      - <<: *restore_lock
-      - run: npm audit
   test:
     <<: *build_image
     steps:
@@ -129,9 +123,6 @@ workflows:
       - checksize:
           requires:
             - install
-      - audit:
-          requires:
-            - install
       - test:
           requires:
             - install
@@ -145,6 +136,5 @@ workflows:
           requires:
             - lint
             - typecheck
-            - audit
             - build-asset
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,6 @@ workflows:
       - checksize:
           requires:
             - install
-      - audit:
-          requires:
-            - install
       - test:
           requires:
             - install
@@ -145,6 +142,20 @@ workflows:
           requires:
             - lint
             - typecheck
-            - audit
             - build-asset
             - test
+  daily_audit:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - install
+      - audit:
+          requires:
+            - install
+
+  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,12 @@ jobs:
       - <<: *restore
       - <<: *restore_lock
       - run: npm run checksize
+  audit:
+    <<: *build_image
+    steps:
+      - <<: *restore
+      - <<: *restore_lock
+      - run: npm audit
   test:
     <<: *build_image
     steps:
@@ -123,6 +129,9 @@ workflows:
       - checksize:
           requires:
             - install
+      - audit:
+          requires:
+            - install
       - test:
           requires:
             - install
@@ -136,5 +145,6 @@ workflows:
           requires:
             - lint
             - typecheck
+            - audit
             - build-asset
             - test


### PR DESCRIPTION
## 経緯

直近で `npm audit` が原因でCIが失敗することが多く発生している。
脆弱性の検知はGitHubが提供する[Security Alerts](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies#githubs-security-alerts-for-vulnerable-dependencies)で検知できる且つ、Greenkeeperでパッチの自動更新ができるためCI上での `npm audit` の実行は廃止したいです。