### PR TITLE
@types/react-router を greenkeeper の ignore に追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
   },
   "greenkeeper": {
     "ignore": [
-      "react-router"
+      "react-router",
+      "@types/react-router"
     ]
   },
   "bundlesize": [


### PR DESCRIPTION
#301 で言及されて居るように react-router を 3 で止めているためその type 定義も greenkeeper で扱わないようにする設定です.